### PR TITLE
Allow replacement view models to define xsd schema

### DIFF
--- a/Source/Assets/MarkLight/Source/Plugins/Editor/ViewPostprocessor.cs
+++ b/Source/Assets/MarkLight/Source/Plugins/Editor/ViewPostprocessor.cs
@@ -156,12 +156,25 @@ namespace MarkLight.Editor
 
             Utils.SuppressLogging = true;
 
+            var replacedViewModels =
+                from viewType in ViewPresenter.Instance.ViewTypeDataList
+                where !String.IsNullOrEmpty(viewType.ReplacesViewModel)
+                select viewType.ReplacesViewModel;
+
             // generate XSD schema based on view type data
             foreach (var viewType in ViewPresenter.Instance.ViewTypeDataList)
             {
+                if (replacedViewModels.Contains(viewType.ViewTypeName))
+                {
+                    // skip replaced view models because the replacement view model will define the schema
+                    continue;
+                }
+
+                var elementName = String.IsNullOrEmpty(viewType.ReplacesViewModel) ? viewType.ViewTypeName : viewType.ReplacesViewModel;
+
                 sb.AppendLine();
-                sb.AppendFormat("  <xs:element name=\"{0}\" type=\"{0}\" />{1}", viewType.ViewTypeName, Environment.NewLine);
-                sb.AppendFormat("  <xs:complexType name=\"{0}\">{1}", viewType.ViewTypeName, Environment.NewLine);
+                sb.AppendFormat("  <xs:element name=\"{0}\" type=\"{0}\" />{1}", elementName, Environment.NewLine);
+                sb.AppendFormat("  <xs:complexType name=\"{0}\">{1}", elementName, Environment.NewLine);
                 sb.AppendFormat("    <xs:sequence>{0}", Environment.NewLine);
                 sb.AppendFormat("      <xs:any processContents=\"lax\" minOccurs=\"0\" maxOccurs=\"unbounded\" />{0}", Environment.NewLine);
                 sb.AppendFormat("    </xs:sequence>{0}", Environment.NewLine);


### PR DESCRIPTION
When using the `ReplacesViewModel` attribute I've noticed the xsd schema didn't update to reflect my extra fields in intellisense after I clicked the Generate Schema button on the View Presenter component in the Inspector.

Consider the following code:
```
namespace MarkLight.Views.UI
{
    [ReplacesViewModel("Label")]
    class MyLabel : Label
    {
        public string MyCustomField;
    }
}
```

`<Label Text="Some Text" MyCustomField="MyCustomData" />`

When adding the `MyCustomField` attribute the intellisense did not provide this attribute as an option. So this pull request fixes the issue by skipping all view models that are replaced and then lets the replacement view models define the xsd schema.
