### PR TITLE
Fixed bug when serializing a color on some locales.

### DIFF
--- a/Source/Assets/MarkLight/Source/Plugins/ValueConverters/ColorValueConverter.cs
+++ b/Source/Assets/MarkLight/Source/Plugins/ValueConverters/ColorValueConverter.cs
@@ -219,7 +219,7 @@ namespace MarkLight.ValueConverters
         public override string ConvertToString(object value)
         {
             Color color = (Color)value;
-            return String.Format("{0},{1},{2},{3}", color.r, color.g, color.b, color.a);
+            return String.Format(CultureInfo.InvariantCulture, "{0},{1},{2},{3}", color.r, color.g, color.b, color.a);
         }
 
         /// <summary>


### PR DESCRIPTION
This bug caused the decimal separator to be comma instead of a dot.

Resulted serialization was for example "0,4901961,0,4901961,0,4901961,1". With this fix it is the correct version "0.4901961,0.4901961,0.4901961,1".

How to reproduce:
- Set computer to danish locale (or other locale with comma as decimal separator)
- Follow tutorial at https://koyoki.github.io/marklight/docs/tutorials/gettingstarted.html until "Adding View Actions".
- Set theme to Flat and let the views reload.
- Inspect the first button and in the Button (script) component find View Field State Values. Expand this and expand the second ImageComponent.color. The value of this property should be "0,4901961,0,4901961,0,4901961,1".
- When running the game an exception is thrown on startup and when triggering mouseout on the button.